### PR TITLE
fix: use OpenSSH format for SSH private keys

### DIFF
--- a/src/transform.py
+++ b/src/transform.py
@@ -814,18 +814,26 @@ class OnePasswordToBitwarden:
                 continue
             
             # Match private key by multiple criteria
-            if (field_id == 'private_key' or 
+            if (field_id == 'private_key' or
                 field_id == 'privatekey' or
                 field_type == 'SSHKEY' or
-                'private' in field_label):
-                raw_private_key = value
-            # Match public key
-            elif (field_id == 'public_key' or 
+                'private key' in field_label):
+                # Prefer OpenSSH format from ssh_formats if available
+                # (Bitwarden SSH Agent requires OpenSSH format, not PKCS#8)
+                ssh_formats = field.get('ssh_formats', {})
+                openssh_data = ssh_formats.get('openssh', {})
+                if openssh_data.get('value'):
+                    raw_private_key = openssh_data['value']
+                else:
+                    raw_private_key = value
+            # Match public key (use 'public key' not 'public' to avoid
+            # matching unrelated fields like 'public url')
+            elif (field_id == 'public_key' or
                   field_id == 'publickey' or
-                  'public' in field_label):
+                  'public key' in field_label):
                 raw_public_key = value
             # Match fingerprint
-            elif (field_id == 'fingerprint' or 
+            elif (field_id == 'fingerprint' or
                   'fingerprint' in field_label):
                 raw_fingerprint = value
         


### PR DESCRIPTION
## Summary

- Prefer OpenSSH format from `field.ssh_formats.openssh.value` over PKCS#8 from `field.value` when extracting SSH private keys
- Fix overly broad label matching (`'public' in label` → `'public key' in label`) that caused fields like "public url" to overwrite the actual public key

## Problem

1Password stores SSH private keys in two formats simultaneously:
- `field.value` → PKCS#8 (`-----BEGIN PRIVATE KEY-----`)
- `field.ssh_formats.openssh.value` → OpenSSH (`-----BEGIN OPENSSH PRIVATE KEY-----`)

The current code takes `field.value` (PKCS#8). Bitwarden's SSH Agent requires OpenSSH format — keys imported with PKCS#8 appear in the vault but are **invisible to `ssh-add -l`** and don't work for SSH connections.

Additionally, the label matching `'public' in field_label` is too broad and matches unrelated custom fields like "public url", overwriting the actual SSH public key with a URL string.

## Testing

Tested end-to-end:
1. Ran migration on 1Password SSH keys with the fix
2. Imported via `bw import bitwardenjson`
3. Confirmed keys appear in `ssh-add -l` after Bitwarden Desktop lock/unlock
4. Verified both the OpenSSH format fix and the label matching fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)